### PR TITLE
Fix Card placeholder height when dragging

### DIFF
--- a/src/components/Board/components/DefaultCard/index.js
+++ b/src/components/Board/components/DefaultCard/index.js
@@ -1,16 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import CardSkeleton from '../CardSkeleton'
 import CursorPointer from '../CursorPointer'
-
-const DefaultCard = styled(CardSkeleton)`
-  border-radius: 3px;
-  background-color: #fff;
-
-  ${({ dragging }) => dragging && `
-    box-shadow: 2px 2px grey;
-  `}
-`
 
 const CardTitle = styled.div`
   border-bottom: 1px solid #eee;
@@ -26,7 +16,7 @@ const CardDescription = styled.div`
 
 export default function ({ children: card, dragging, allowRemoveCard, onCardRemove }) {
   return (
-    <DefaultCard dragging={dragging}>
+    <div>
       <span>
         <CardTitle>
           <span>{card.title}</span>
@@ -34,6 +24,6 @@ export default function ({ children: card, dragging, allowRemoveCard, onCardRemo
         </CardTitle>
       </span>
       <CardDescription>{card.description}</CardDescription>
-    </DefaultCard>
+    </div>
   )
 }

--- a/src/components/Board/components/DefaultCard/index.spec.js
+++ b/src/components/Board/components/DefaultCard/index.spec.js
@@ -31,24 +31,6 @@ describe('<DefaultCard />', () => {
     expect(subject.queryByText('Description')).toBeVisible()
   })
 
-  describe('about the style on dragging', () => {
-    describe('when the component receives "dragging"', () => {
-      beforeEach(() => mount({ dragging: true }))
-
-      it('applies the gray background color to the card', () => {
-        expect(subject.container.querySelector('div')).toHaveStyle('box-shadow: 2px 2px grey;')
-      })
-    })
-
-    describe('when the component does not receive "dragging"', () => {
-      beforeEach(() => mount())
-
-      it('does not apply the gray background color to the card', () => {
-        expect(subject.container.querySelector('div')).not.toHaveStyle('box-shadow: 2px 2px grey;')
-      })
-    })
-  })
-
   describe('about the remove card button', () => {
     describe('when the component does not receive the "allowRemoveCard" prop', () => {
       beforeEach(() => mount({ onCardRemove }))

--- a/src/components/Board/components/Lane/components/Card/index.js
+++ b/src/components/Board/components/Lane/components/Card/index.js
@@ -1,19 +1,31 @@
 import React from 'react'
 import { Draggable } from 'react-beautiful-dnd'
+import styled from 'styled-components'
+import CardSkeleton from '../../../CardSkeleton'
+
+const DraggableCard = styled(CardSkeleton)`
+  border-radius: 3px;
+  background-color: #fff;
+
+  ${({ dragging }) => dragging && `
+    box-shadow: 2px 2px grey;
+  `}
+`
 
 function Card ({ children, index, renderCard, disableCardDrag }) {
   return (
     <Draggable draggableId={String(children.id)} index={index} isDragDisabled={disableCardDrag}>
       {(provided, { isDragging }) => {
         return (
-          <div
+          <DraggableCard
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             data-testid='card'
+            dragging={isDragging}
           >
             {renderCard(isDragging)}
-          </div>
+          </DraggableCard>
         )
       }}
     </Draggable>

--- a/src/components/Board/components/Lane/components/Card/index.spec.js
+++ b/src/components/Board/components/Lane/components/Card/index.spec.js
@@ -42,4 +42,30 @@ describe('<Card />', () => {
       expect(defaultCard).toHaveBeenCalledWith(true)
     })
   })
+
+  describe('about the style on dragging', () => {
+    describe('when the component receives "dragging"', () => {
+      beforeEach(() => {
+        callbacks.isDragging(true)
+        mount()
+      })
+      afterEach(() => { callbacks.isDragging(false) })
+
+      it('applies the gray background color to the card', () => {
+        expect(subject.container.querySelector('div')).toHaveStyle('box-shadow: 2px 2px grey;')
+      })
+    })
+
+    describe('when the component does not receive "dragging"', () => {
+      beforeEach(() => {
+        callbacks.isDragging(false)
+        mount()
+      })
+      afterEach(() => { callbacks.isDragging(false) })
+
+      it('does not apply the gray background color to the card', () => {
+        expect(subject.container.querySelector('div')).not.toHaveStyle('box-shadow: 2px 2px grey;')
+      })
+    })
+  })
 })


### PR DESCRIPTION
When drag and dropping a Card, the height from the placeholder didn't match the height of the actual card.

To fix it, I moved the styles from the DefaultCard to the Card.
