### PR TITLE
Fix mouse pointer on lane's title

### DIFF
--- a/src/components/Board/components/DefaultLaneHeader/index.js
+++ b/src/components/Board/components/DefaultLaneHeader/index.js
@@ -29,6 +29,18 @@ const Input = styled.input`
   }
 `
 
+function LaneTitle ({ allowRenameLane, onClick, children: title }) {
+  return allowRenameLane ? (
+    <CursorPointer onClick={onClick}>
+      {title}
+    </CursorPointer>
+  ) : (
+    <span>
+      {title}
+    </span>
+  )
+}
+
 function useRenameMode (state) {
   const [renameMode, setRenameMode] = useState(state)
 
@@ -57,7 +69,7 @@ export default function ({ children: lane, allowRemoveLane, onLaneRemove, allowR
 
   return (
     <LaneHeaderSkeleton>
-      {allowRenameLane && renameMode ? (
+      {renameMode ? (
         <form onSubmit={() => handleRenameLane(titleInput)}>
           <span>
             <Input type='text' value={titleInput} onChange={({ target: { value } }) => setTitleInput(value)} autoFocus />
@@ -69,9 +81,9 @@ export default function ({ children: lane, allowRemoveLane, onLaneRemove, allowR
         </form>
       ) : (
         <>
-          <CursorPointer onClick={handleRenameMode}>
+          <LaneTitle allowRenameLane={allowRenameLane} onClick={handleRenameMode}>
             {title}
-          </CursorPointer>
+          </LaneTitle>
           {allowRemoveLane && <span onClick={() => onLaneRemove(lane)}>×</span>}
         </>
       )}

--- a/src/components/Board/components/DefaultLaneHeader/index.spec.js
+++ b/src/components/Board/components/DefaultLaneHeader/index.spec.js
@@ -68,11 +68,16 @@ describe('<DefaultLaneHeader />', () => {
 
   describe('about the lane title renaming', () => {
     describe('when the component does not receive the "allowRenameLane" prop', () => {
-      describe('when the user clicks on the lane title', () => {
-        beforeEach(() => {
-          mount({ onLaneRename })
-          fireEvent.click(subject.queryByText('Lane title'))
+      beforeEach(() => mount({ onLaneRename }))
+
+      describe('when the user moves the mouse over the title', () => {
+        it('does not show a mouse pointer', () => {
+          expect(subject.queryByText('Lane title')).not.toHaveStyle('cursor: pointer')
         })
+      })
+
+      describe('when the user clicks on the lane title', () => {
+        beforeEach(() => fireEvent.click(subject.queryByText('Lane title')))
 
         it('does not allow the user to rename the lane', () => {
           expect(subject.queryByText('Lane title')).toBeInTheDocument()
@@ -86,11 +91,16 @@ describe('<DefaultLaneHeader />', () => {
     })
 
     describe('when the component receives the "allowRenameLane" prop', () => {
-      describe('when the user clicks on the lane title', () => {
-        beforeEach(() => {
-          mount({ allowRenameLane: true, onLaneRename })
-          fireEvent.click(subject.queryByText('Lane title'))
+      beforeEach(() => mount({ allowRenameLane: true, onLaneRename }))
+
+      describe('when the user moves the mouse over the title', () => {
+        it('shows a mouse pointer', () => {
+          expect(subject.queryByText('Lane title')).toHaveStyle('cursor: pointer')
         })
+      })
+
+      describe('when the user clicks on the lane title', () => {
+        beforeEach(() => fireEvent.click(subject.queryByText('Lane title')))
 
         it('does not call the "onLaneRename" callback', () => {
           expect(onLaneRename).not.toHaveBeenCalled()


### PR DESCRIPTION
It's showing the mouse pointer even when it's not allowed to rename the lane.