### PR TITLE
Fix multiline text in Card

### DIFF
--- a/src/components/Board/components/Lane/components/Card/index.js
+++ b/src/components/Board/components/Lane/components/Card/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 
 const CardTemplate = styled.div`
   display: inline-block;
+  white-space: normal;
 `
 
 function Card ({ children, index, renderCard, disableCardDrag }) {


### PR DESCRIPTION
The property `white-space: nowrap` was inherited from the Lane to the Card, so I changed it at CardTemplate so both the default and custom cards inherit the normal text behaviour.

Before and after:
![pr](https://user-images.githubusercontent.com/21962999/66255350-b3cf9000-e782-11e9-922b-620f3d612b31.png)