### PR TITLE
Add the missing `,` in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const board = {
           description: 'Add capability to add a card in a lane'
         },
       ]
-    }
+    },
     {
       id: 2,
       title: 'Doing',


### PR DESCRIPTION
copying this code snippet causes webstorm to warn the missing `,`. add it to fix the issue