### PR TITLE
Fix droppable column height sizing

### DIFF
--- a/src/components/Board/components/Column/index.js
+++ b/src/components/Board/components/Column/index.js
@@ -8,6 +8,7 @@ import CardAdder from './components/CardAdder'
 
 export const StyledColumn = styled.div`
   height: 100%;
+  min-height: 28px;
   display: inline-block;
   padding: 15px;
   border-radius: 2px;
@@ -17,7 +18,8 @@ export const StyledColumn = styled.div`
 `
 
 const DroppableColumn = withDroppable(styled.div`
-  min-height: 28px;
+  height: inherit;
+  min-height: inherit;
 `)
 
 function Column({
@@ -28,11 +30,11 @@ function Column({
   disableColumnDrag,
   disableCardDrag,
   onCardNew,
-  allowAddCard,
+  allowAddCard
 }) {
   return (
     <Draggable draggableId={`column-draggable-${children.id}`} index={columnIndex} isDragDisabled={disableColumnDrag}>
-      {(columnProvided) => (
+      {columnProvided => (
         <StyledColumn ref={columnProvided.innerRef} {...columnProvided.draggableProps} data-testid='column'>
           <div {...columnProvided.dragHandleProps} data-testid='column-header'>
             {renderColumnHeader(children)}
@@ -44,7 +46,7 @@ function Column({
                 <Card
                   key={card.id}
                   index={index}
-                  renderCard={(dragging) => renderCard(children, card, dragging)}
+                  renderCard={dragging => renderCard(children, card, dragging)}
                   disableCardDrag={disableCardDrag}
                 >
                   {card}

--- a/src/components/Board/components/Column/index.js
+++ b/src/components/Board/components/Column/index.js
@@ -30,11 +30,11 @@ function Column({
   disableColumnDrag,
   disableCardDrag,
   onCardNew,
-  allowAddCard,
+  allowAddCard
 }) {
   return (
     <Draggable draggableId={`column-draggable-${children.id}`} index={columnIndex} isDragDisabled={disableColumnDrag}>
-      {(columnProvided) => (
+      {columnProvided => (
         <StyledColumn ref={columnProvided.innerRef} {...columnProvided.draggableProps} data-testid='column'>
           <div {...columnProvided.dragHandleProps} data-testid='column-header'>
             {renderColumnHeader(children)}
@@ -46,7 +46,7 @@ function Column({
                 <Card
                   key={card.id}
                   index={index}
-                  renderCard={(dragging) => renderCard(children, card, dragging)}
+                  renderCard={dragging => renderCard(children, card, dragging)}
                   disableCardDrag={disableCardDrag}
                 >
                   {card}

--- a/src/components/Board/components/Column/index.js
+++ b/src/components/Board/components/Column/index.js
@@ -30,11 +30,11 @@ function Column({
   disableColumnDrag,
   disableCardDrag,
   onCardNew,
-  allowAddCard
+  allowAddCard,
 }) {
   return (
     <Draggable draggableId={`column-draggable-${children.id}`} index={columnIndex} isDragDisabled={disableColumnDrag}>
-      {columnProvided => (
+      {(columnProvided) => (
         <StyledColumn ref={columnProvided.innerRef} {...columnProvided.draggableProps} data-testid='column'>
           <div {...columnProvided.dragHandleProps} data-testid='column-header'>
             {renderColumnHeader(children)}
@@ -46,7 +46,7 @@ function Column({
                 <Card
                   key={card.id}
                   index={index}
-                  renderCard={dragging => renderCard(children, card, dragging)}
+                  renderCard={(dragging) => renderCard(children, card, dragging)}
                   disableCardDrag={disableCardDrag}
                 >
                   {card}


### PR DESCRIPTION
The column droppable area was not respecting the column height. So i changed some css so  the droppable area will be always the min-height or the height of the column. This way who is styling the column do not need to worry about using height ou min-height.

Basically, when setting the colomn height or min-height you'll be able the drag the cards to any part of it.

fix #300 