### PR TITLE
Remove nested contexts in favor of inline them

### DIFF
--- a/src/components/Board/index.spec.js
+++ b/src/components/Board/index.spec.js
@@ -1846,4 +1846,27 @@ describe('<Board />', () => {
       })
     })
   })
+
+  describe('when the board is uncontrolled', () => {
+    function mount({ Component = Board, initialBoard = board, ...props } = {}) {
+      return render(<Component initialBoard={initialBoard} {...props} />)
+    }
+
+    it('allows a card to be added when it receives the "allowAddCard" and the "onNewCardConfirm" props', async () => {
+      const onNewCardConfirm = jest.fn((column) => new Promise((resolve) => resolve({ id: 999, ...column })))
+      const subject = mount({ allowAddCard: true, onNewCardConfirm, onCardNew: () => {} })
+
+      fireEvent.click(subject.queryAllByText('+')[0])
+      fireEvent.change(subject.container.querySelector('input[name="title"]'), {
+        target: { value: 'Card title' },
+      })
+      fireEvent.change(subject.container.querySelector('input[name="description"]'), {
+        target: { value: 'Card description' },
+      })
+      fireEvent.click(subject.queryByText('Add'))
+
+      expect(await screen.findByTestId('card-999')).toBeInTheDocument()
+      expect(screen.queryAllByTestId(/card/)).toHaveLength(4)
+    })
+  })
 })


### PR DESCRIPTION
### Description

A stepping stone to:
* Make the board accessible.
* Use `screen.getByRole` queries.

### Type of change

- [ ] 🐛 Bug fix
- [ ] 💻 New feature
- [ ] 📖 Documentation
- [ ] 💅 Layout
- [x] 🧹 Chore

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I updated the docs related to the changes

<!-- PLEASE, OPEN THIS PR AS DRAFT IF IT'S NOT THROUGH YET. -->
